### PR TITLE
Update setup-ipfs action & Use LimitReader

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up IPFS ${{ matrix.ipfs }}
-        uses: ibnesayeed/setup-ipfs@f84d4bdcdb4e5ff7d6bc4c6cb28f117584a50538
+        uses: ibnesayeed/setup-ipfs@8f99e662ba25be9a1158fffdeea57e9024468bfd
         id: ipfs_setup
         with:
           ipfs_version: ${{ matrix.ipfs }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Test
         env:
-          STORAGE_IPFS_INTEGRATION_TEST: ${{ secrets.STORAGE_INTEGRATION_TEST }}
+          STORAGE_IPFS_INTEGRATION_TEST: "on"
           STORAGE_IPFS_ENDPOINT: "http:127.0.0.1:5001"
           STORAGE_IPFS_GATEWAY: "http:127.0.0.1:8080"
         run: make integration_test

--- a/storage.go
+++ b/storage.go
@@ -192,6 +192,7 @@ func (s *Storage) write(ctx context.Context, path string, r io.Reader, size int6
 		}
 		r = bytes.NewReader([]byte{})
 	}
+	r = io.LimitReader(r, size)
 
 	if opt.HasIoCallback {
 		r = iowrap.CallbackReader(r, opt.IoCallback)


### PR DESCRIPTION
1. Update setup-ipfs action
2. Set Integration_test always on
3. Use LimitReader, I found that there is a certain chance of 'connection reset by remote host' when the actual size of the reader is larger than the size